### PR TITLE
Resolve some environment issues of integration test

### DIFF
--- a/integration_test/README.md
+++ b/integration_test/README.md
@@ -1,5 +1,13 @@
 ## Test Setup
 
+#### Requirements
+We only checked these test cases on specific environment. Result of test on different environment is not guaranteed.
+
+* Physical Machine (Xeon L5640 @ 2.27 X 2 socket, 48 GB Memory)
+* CentOS 6.3 & CentOS 6.6
+* python 2.7
+* tcl 8.5+ required
+
 #### Build nbase-arc with gcov option.
 ```
 $ make gcov
@@ -13,8 +21,11 @@ $ make gcov32
 ```
 
 #### Install zookeeper ensemble.
-* Install three copies of zookeeper in ~/bin/zk1, ~/bin/zk2, and ~/bin/zk3
+* Install three copies of zookeeper in ~/bin/zk1, ~/bin/zk2, and ~/bin/zk3  
+  For integration test, these zookeeper paths are fixed in test case for zookeeper failure.
+
 * Set up zookeeper config.
+
 ```
 $ mv ~/bin/zk1/conf/zoo_sample.cfg ~/bin/zk1/conf/zoo.cfg
 $ vi ~/bin/zk1/conf/zoo.cfg

--- a/integration_test/test_protocol_error.py
+++ b/integration_test/test_protocol_error.py
@@ -45,7 +45,14 @@ class TestProtocolError(unittest.TestCase):
         self.server_connect(server_mgmt, host, port)
 
     def send_command_and_expect(self, server, cmd, expect):
-        server.write(cmd)
+        try:
+            server.write(cmd)
+        except:
+            # When test sends a very big bulk string to the server, sometimes, write command may throw
+            # exception, "Connection reset by peer". This is because redis closes connection as soon as
+            # it notices that received data exceeds protocol limit, even if sending data is not finished yet.
+            pass
+
         ret = server.read_until(expect)
         self.assertEquals(ret, expect, "Server didn't respond properly. expect:%s, ret:%s" % (expect, ret))
 

--- a/integration_test/testbase.py
+++ b/integration_test/testbase.py
@@ -18,7 +18,7 @@ resource_files = (
 )
 
 
-def setup_binaries( clusters, skip_copy_binaries ):
+def setup_binaries( clusters, skip_copy_binaries, opt_32bit_binary_test ):
     if not os.path.exists( c.homedir ):
         os.mkdir( c.homedir )
     if not os.path.exists( c.logdir ):
@@ -34,7 +34,7 @@ def setup_binaries( clusters, skip_copy_binaries ):
                     continue
                 server_id_dict[id] = True
 
-                if copy_binaries(id) is not 0:
+                if copy_binaries(id, opt_32bit_binary_test) is not 0:
                     util.log('failed to copy_binaries, server_id: %d' % server['id'])
                     return -1
     util.log('initialize done')
@@ -420,7 +420,7 @@ def setup_cm( id ):
     return 0
 
 
-def copy_binaries( id ):
+def copy_binaries( id, opt_32bit_binary_test ):
     try:
         util.copy_smrreplicator( id )
         util.copy_gw( id )
@@ -430,10 +430,12 @@ def copy_binaries( id ):
         util.copy_dump_util_plugin( id )
         util.copy_log_util( id )
         util.copy_capi_so_file( id )
-        util.copy_capi32_so_file( id )
         util.copy_capi_test_server( id )
-        util.copy_capi32_test_server( id )
         util.copy_cm( id )
+
+        if opt_32bit_binary_test:
+            util.copy_capi32_so_file( id )
+            util.copy_capi32_test_server( id )
 
     except IOError as e:
         print e

--- a/integration_test/testrunner.py
+++ b/integration_test/testrunner.py
@@ -155,7 +155,7 @@ def __import__(name, globals=None, locals=None, fromlist=None):
 def signal_handler( *args ):
     exit(-1)
 
-def cleanup_test_env(opt_skip_copy_binaries):
+def cleanup_test_env(opt_skip_copy_binaries, opt_32bit_binary_test):
     # Kill processes
     if testbase.cleanup_processes() != 0:
         util.log('failed to cleanup test environment')
@@ -175,7 +175,7 @@ def cleanup_test_env(opt_skip_copy_binaries):
             srv_id_dict[id] = True
 
     # Setup binaries
-    if testbase.setup_binaries( config.clusters, opt_skip_copy_binaries ) != 0:
+    if testbase.setup_binaries( config.clusters, opt_skip_copy_binaries, opt_32bit_binary_test ) != 0:
         util.log('failed to initialize testbase')
         return -1
 
@@ -291,7 +291,7 @@ def main():
             opt_non_interactive = True
 
     # Clean up test environment
-    if cleanup_test_env(opt_skip_copy_binaries) != 0:
+    if cleanup_test_env(opt_skip_copy_binaries, opt_32bit_binary_test) != 0:
         print 'Clean up test environment fail! Aborting...'
         return -1
 

--- a/integration_test/util.py
+++ b/integration_test/util.py
@@ -242,29 +242,15 @@ def kill_proc( popen ):
 
 
 def _killps_y( name ):
-    return shell_cmd_sync( '%s %s'
-      % ("""
-        function my_ps()
-        {
-          ps $@ -u $USER -o pid,%cpu,%mem,bsdtime,command;
-        }
+    pids = [pid for pid in os.listdir('/proc') if pid.isdigit()]
 
-        function killps_y()
-        {
-          local pid pname
-          if [ $# -lt 1 ]; then
-            echo "Usage: killps pattern"
-            return
-          fi
-
-          for pid in $(my_ps|awk '!/awk/ && $0~pat { print $1 }' pat=${!#} ); do
-            pname=$(my_ps | awk '$1~var { print $5 }' var=$pid )
-            kill -9 $pid
-          done
-        }
-
-        killps_y""", name), 0 )
-
+    for pid in pids:
+        try:
+            cmdline = open(os.path.join('/proc', pid, 'cmdline'), 'rb').read()
+            if name in cmdline:
+                os.kill(int(pid), signal.SIGKILL)
+        except IOError:
+            continue
 
 def write_executable_file( data, dir, file_name ):
     if not os.path.exists( dir ):


### PR DESCRIPTION
- Add test requirments to README.md
- Replace shell script which is not portable.
- Exclude copying of 32bit binaries when option is set only for 64bit.
- Fix timing issue when test runs on low performance machines.
