### PR TITLE
Heavy key is deleted in a separate background thread. 

### DIFF
--- a/integration_test/redis_sock.py
+++ b/integration_test/redis_sock.py
@@ -1,0 +1,71 @@
+#
+# Copyright 2015 Naver Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from socket import *
+
+class RedisClient:
+    ''' simple redis client that works only in request/response mode '''
+    def __init__( self, ip, port ):
+        self.ip = ip
+        self.port = port
+        self.sock = socket(AF_INET, SOCK_STREAM)
+        self.sock.connect((ip, port))
+
+    def close(self):
+        self.sock.close()
+
+    def io_read(self, len = -1):
+        s = self.sock
+        if len == -1: # read a line that ends with \r\n
+	    prev_c = c = None
+            ret = ''
+            while True:
+		prev_c = c
+                c = s.recv(1)
+                if prev_c == '\r' and c == '\n': 
+		  return ret[:-1]
+		ret = ret + c
+        else:
+            return s.recv(len)
+
+    def parse_response_(self):
+        payload = self.io_read()
+        prefix, data = payload[0], payload[1:].strip()
+        if prefix == "+": # ok
+            return True, data
+        elif prefix == "-": # error
+            return False, data
+        elif prefix == ":": # integer reply
+            len = int(data)
+            return True, len
+        elif prefix == "$": # bulk reply
+            len = int(data)
+            nextchunk = self.io_read(len+2)
+	    return True, nextchunk[:-2]
+        elif prefix == "*": # multibulk reply
+            count = int(data)
+            if count == -1:
+                return True, None
+            resp = []
+            for i in range (0, count):
+                ok, r = self.parse_response_()
+                resp.append(r)
+            return True, resp
+
+    def do_request(self, cmd):
+        assert (cmd.endswith('\r\n'))
+        self.sock.send(cmd)
+        return self.parse_response_()

--- a/integration_test/test_bgdel.py
+++ b/integration_test/test_bgdel.py
@@ -1,0 +1,180 @@
+#
+# Copyright 2015 Naver Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import unittest
+import testbase
+import util
+import time
+import copy
+import redis_sock
+import config
+import default_cluster
+
+class TestBackgroundDelete( unittest.TestCase ):
+    cluster = config.clusters[0]
+
+    @classmethod
+    def setUpClass( cls ):
+        ret = default_cluster.initialize_starting_up_smr_before_redis( cls.cluster )
+        if ret is not 0:
+            default_cluster.finalize( cls.cluster )
+        assert (ret == 0)
+        return 0
+
+    @classmethod
+    def tearDownClass( cls ):
+        ret = default_cluster.finalize( cls.cluster )
+        assert (ret == 0)
+        return 0
+
+    def setUp( self ):
+        util.set_process_logfile_prefix( 'TestBackgroundDelete_%s' % self._testMethodName )
+        server = self.cluster['servers'][0]
+        self.redis = redis_sock.RedisClient(server['ip'], server['redis_port'])
+
+    def tearDown( self ):
+        if self.redis != None:
+            self.redis.close()
+        return 0
+
+    def get_info(self, section, key):
+        redis = self.redis
+        ok, data = redis.do_request("info %s\r\n" % section)
+        assert (ok == True)
+        items = data.split('\r\n')
+        assert (len(items) > 0)
+        for item in items:
+            if item.startswith(key):
+                return item[len(key)+1:].strip()
+        return None
+
+    def test_config_get_set ( self ):
+        redis = self.redis
+
+        ok, data = redis.do_request("config get object-bio-delete-min-elems\r\n");
+        val = int(data[1].strip())
+        assert (ok == True and val > 0)
+
+        ok, data = redis.do_request("config set object-bio-delete-min-elems %d\r\n" %  (val - 1))
+        assert (ok == True)
+
+        ok, data = redis.do_request("config get object-bio-delete-min-elems\r\n");
+        newval = int(data[1].strip())
+        assert (ok == True and newval == (val - 1))
+
+        ok, data = redis.do_request("config set object-bio-delete-min-elems %d\r\n" %  val)
+        assert (ok == True)
+        redis.close()
+
+    def test_bgdel_config_works (self):
+        redis = self.redis
+
+        # save original min-elems, delete_keys
+        ok, data = redis.do_request("config get object-bio-delete-min-elems\r\n");
+        min_elem_saved = int(data[1].strip())
+        del_keys = int(self.get_info('stats', 'background_deleted_keys'))
+
+        # min-elems 0 means no background delete
+        min_elems = 0
+        ok, data = redis.do_request("config set object-bio-delete-min-elems %d\r\n" % min_elems)
+        assert (ok == True)
+        for i in range (0, 10000): # big enough
+            ok, data = redis.do_request("lpush list_key 1\r\n")
+            assert (ok == True)
+        ok, data = redis.do_request("del list_key\r\n")
+        assert (ok == True)
+        time.sleep(1)
+        assert (del_keys == int(self.get_info('stats', 'background_deleted_keys')))
+
+        # set min-elems to 10000
+        min_elems = 10000
+        ok, data = redis.do_request("config set object-bio-delete-min-elems %d\r\n" % min_elems)
+        assert (ok == True)
+
+        # key that is not a target
+        for i in range (0, min_elems - 1):
+            ok, data = redis.do_request("lpush list_key 1\r\n")
+            assert (ok == True)
+        ok, data = redis.do_request("del list_key\r\n")
+        assert (ok == True)
+        time.sleep(1)
+        assert (del_keys == int(self.get_info('stats', 'background_deleted_keys')))
+
+        # key that is a target
+        for i in range (0, min_elems):
+            ok, data = redis.do_request("lpush list_key 1\r\n")
+            assert (ok == True)
+        ok, data = redis.do_request("del list_key\r\n")
+        assert (ok == True)
+        time.sleep(1) # wait sufficient time (delete in background)
+        assert ((del_keys + 1) == int(self.get_info('stats', 'background_deleted_keys')))
+
+        # restore min-elems
+        min_elems = min_elem_saved
+        ok, data = redis.do_request("config set object-bio-delete-min-elems %d\r\n" % min_elems)
+        assert (ok == True)
+
+    def test_response_time (self):
+        redis = self.redis
+
+        # save deleted keys
+        del_keys = int(self.get_info('stats', 'background_deleted_keys'))
+
+        # make big keys
+        list_elems = '1 2 3 4 5 6 1 2 3 4 5 6 1 2 3 4 5 6 1 2 3 4 5 6 1 2 3 4 5 6'
+        for i in range (0, 10000):
+            ok, data = redis.do_request('hset key_hash key%d value%d\r\n' % (i, i))
+            assert (ok == True)
+            ok, data = redis.do_request('zadd key_zset %d value%d\r\n' % (i, i))
+            assert (ok == True)
+            ok, data = redis.do_request('lpush key_list %s\r\n' % list_elems)
+            assert (ok == True)
+            ok, data = redis.do_request('lpush key_list %s\r\n' % list_elems)
+            assert (ok == True)
+            ok, data = redis.do_request('lpush key_list %s\r\n' % list_elems)
+            assert (ok == True)
+            ok, data = redis.do_request('sadd key_set elem%d\r\n' % i)
+            assert (ok == True)
+            ok, data = redis.do_request('s3sadd * key_sss svc key%d val%d 1000000\r\n' % (i, i))
+            assert (ok == True)
+
+        # delete keys
+        delete_begin = int(round(time.time() * 1000))
+
+        ok, data = redis.do_request('del key_hash\r\n')
+        assert (ok == True)
+        ok, data = redis.do_request('del key_zset\r\n')
+        assert (ok == True)
+        ok, data = redis.do_request('del key_list\r\n')
+        assert (ok == True)
+        ok, data = redis.do_request('del key_set\r\n')
+        assert (ok == True)
+        ok, data = redis.do_request('del key_sss\r\n')
+        assert (ok == True)
+
+        delete_end = int(round(time.time() * 1000))
+        assert (delete_end - delete_begin < 10) # 10 msec should suffice
+
+        # wait background delete completes
+        count = 0
+        del_keys_now = 0
+        while count < 20: # wait at most about 10 sec. (0.5*20)
+            del_keys_now = int(self.get_info('stats', 'background_deleted_keys'))
+            if del_keys + 5 == del_keys_now:
+                break
+            time.sleep(0.5)
+            count = count + 1
+        assert(del_keys + 5 == del_keys_now)

--- a/redis-2.8.8/redis.conf
+++ b/redis-2.8.8/redis.conf
@@ -467,6 +467,11 @@ slave-priority 100
 # memory-max-allowed-percentage 90
 # memory-hard-limit-percentage 95
 
+# bio key delete
+# If the number of elements in a object exceeds given value, object destruction
+# is performed in bio thread
+object-bio-delete-min-elems 100
+
 ############################## APPEND ONLY MODE ###############################
 
 # By default Redis asynchronously dumps the dataset on disk. This mode is

--- a/redis-2.8.8/src/bio.h
+++ b/redis-2.8.8/src/bio.h
@@ -30,6 +30,14 @@
 /* Exported API */
 void bioInit(void);
 void bioCreateBackgroundJob(int type, void *arg1, void *arg2, void *arg3);
+#ifdef NBASE_ARC
+void bioDisableBackgroundDelete(void);
+void bioPrepareInit(void);
+void safeIncrRefCount(void *robj);
+int safeDecrRefCount(void *robj);
+int isBackgroundDeleteCandidate(void);
+void bioCreateBackgroundDeleteJob(int type, void *arg1);
+#endif
 unsigned long long bioPendingJobsOfType(int type);
 void bioWaitPendingJobsLE(int type, unsigned long long num);
 time_t bioOlderJobOfType(int type);
@@ -38,4 +46,9 @@ void bioKillThreads(void);
 /* Background job opcodes */
 #define REDIS_BIO_CLOSE_FILE    0 /* Deferred close(2) syscall. */
 #define REDIS_BIO_AOF_FSYNC     1 /* Deferred AOF fsync. */
+#ifdef NBASE_ARC
+#define REDIS_BIO_OBJ_DESTRUCT  2 /* Deferred Object Destructor */
+#define REDIS_BIO_NUM_OPS       3
+#else
 #define REDIS_BIO_NUM_OPS       2
+#endif

--- a/redis-2.8.8/src/config.c
+++ b/redis-2.8.8/src/config.c
@@ -295,6 +295,11 @@ void loadServerConfigFromString(char *config) {
             {
                 err = "Invalid percentage of memory hard limit"; goto loaderr;
             }
+        } else if (!strcasecmp(argv[0], "object-bio-delete-min-elems") && argc == 2) {
+            server.object_bio_delete_min_elems = atoi(argv[1]);
+            if (server.object_bio_delete_min_elems < 0) {
+                err = "Invalid number of minimum elements of a structure for background deletion"; goto loaderr;
+            }
 #endif
         } else if (!strcasecmp(argv[0],"include") && argc == 2) {
             loadServerConfig(argv[1],NULL);
@@ -943,6 +948,10 @@ void configSetCommand(redisClient *c) {
             ll <= 0 || ll > 100) goto badfmt;
         server.mem_hard_limit_perc = ll;
         setMemoryLimitValues();
+    } else if (!strcasecmp(c->argv[2]->ptr,"object-bio-delete-min-elems")) {
+        if (getLongLongFromObject(o,&ll) == REDIS_ERR ||
+            ll < 0) goto badfmt;
+        server.object_bio_delete_min_elems = ll;
     } else if (!strcasecmp(c->argv[2]->ptr,"sss-gc-interval")) {
         if (getLongLongFromObject(o,&ll) == REDIS_ERR ||
             ll < 100 || ll > INT_MAX) goto badfmt;
@@ -1026,6 +1035,7 @@ void configGetCommand(redisClient *c) {
     config_get_numerical_field("memory-limit-activation-percentage",server.mem_limit_active_perc);
     config_get_numerical_field("memory-max-allowed-percentage",server.mem_max_allowed_perc);
     config_get_numerical_field("memory-hard-limit-percentage",server.mem_hard_limit_perc);
+    config_get_numerical_field("object-bio-delete-min-elems",server.object_bio_delete_min_elems);
 #endif
     config_get_numerical_field("maxmemory",server.maxmemory);
     config_get_numerical_field("maxmemory-samples",server.maxmemory_samples);

--- a/redis-2.8.8/src/rdb.c
+++ b/redis-2.8.8/src/rdb.c
@@ -47,6 +47,7 @@
 #include "rdb.h"
 #include "rio.h"
 #include "crc16.h"
+#include "bio.h"
 #endif
 
 static int rdbWriteRaw(rio *rdb, void *p, size_t len) {
@@ -932,6 +933,9 @@ int rdbSaveBackground(char *filename) {
         int retval;
 
         /* Child */
+#ifdef NBASE_ARC
+        bioDisableBackgroundDelete();
+#endif
         closeListeningSockets(0);
         redisSetProcTitle("redis-rdb-bgsave");
         retval = rdbSave(filename);

--- a/redis-2.8.8/src/redis.c
+++ b/redis-2.8.8/src/redis.c
@@ -1804,6 +1804,7 @@ void initServerConfig() {
     server.mem_max_allowed_byte = 0;
     server.mem_hard_limit_kb = 0;
 
+    server.object_bio_delete_min_elems = REDIS_OBJ_BIO_DELETE_MIN_ELEMS;
     server.local_ip_addrs = getLocalIpAddrs();
 #endif
 }
@@ -1951,6 +1952,7 @@ void resetServerStats(void) {
 #ifdef NBASE_ARC
     server.stat_numcommands_replied = 0;
     server.stat_numcommands_lcon = 0;
+    server.stat_bgdel_keys = 0;
 #endif
     server.stat_numconnections = 0;
     server.stat_expiredkeys = 0;
@@ -1994,6 +1996,10 @@ void setMemoryLimitValues(void) {
 
 void initServer() {
     int j;
+
+#ifdef NBASE_ARC
+    bioPrepareInit();
+#endif
 
     signal(SIGHUP, SIG_IGN);
     signal(SIGPIPE, SIG_IGN);
@@ -2962,6 +2968,7 @@ sds genRedisInfoString(char *section) {
             "instantaneous_replied_ops_per_sec:%lld\r\n"
             "total_commands_lcon:%lld\r\n"
             "instantaneous_lcon_ops_per_sec:%lld\r\n"
+	    "background_deleted_keys:%lld\r\n"
 #endif
             "rejected_connections:%lld\r\n"
             "sync_full:%lld\r\n"
@@ -2982,6 +2989,7 @@ sds genRedisInfoString(char *section) {
             getOperationsPerSecondWithArg(server.replied_ops_sec_samples),
             server.stat_numcommands_lcon,
             getOperationsPerSecondWithArg(server.lcon_ops_sec_samples),
+	    server.stat_bgdel_keys,
 #endif
             server.stat_rejected_conn,
             server.stat_sync_full,

--- a/redis-2.8.8/src/smr_checkpoint.c
+++ b/redis-2.8.8/src/smr_checkpoint.c
@@ -22,6 +22,9 @@
 #include "redis.h"
 #include "endianconv.h"
 #include "crc16.h"
+#ifdef NBASE_ARC
+#include "bio.h"
+#endif
 
 #ifdef NBASE_ARC
 static sds rdbSetBit (sds bitarray, int bitoffset, int value) {
@@ -168,6 +171,9 @@ static int rdbCheckpointBackground (char *filename, sds bitarray, int hashsize)
         int retval;
 
         /* Child */
+#ifdef NBASE_ARC
+        bioDisableBackgroundDelete();
+#endif
 	closeListeningSockets(0);
         retval = rdbCheckpoint(filename, bitarray, hashsize);
         exitFromChild((retval == REDIS_OK) ? 0 : 1);

--- a/redis-2.8.8/src/t_sss2.c
+++ b/redis-2.8.8/src/t_sss2.c
@@ -2217,6 +2217,12 @@ sssRelease (sss * s)
   zfree (s);
 }
 
+void
+sssUnlinkGc (sss * s3)
+{
+  dlisth_delete(&s3->head);
+}
+
 int
 sssAddValue (sss * s3, void *ks, void *svc, void *key, long long idx,
 	     void *val, long long expire)


### PR DESCRIPTION
reviewers: @cl9200 , @otheng03

When a big key that contains lots of elements in it is deleted, service thread can be blocked for a long time (upto second). 
In this pull request, a new background thread is used to delete keys that contain more than `object-bio-delete-min-elems` (in redis.conf) elements in them. The number of keys that are deleted by the background thread is exposed as `background_deleted_keys` in the `info stats` result.
