### PR TITLE
Fix bug in local_proxy by handling error code of CAPI

### DIFF
--- a/integration_test/basic_op_capi.py
+++ b/integration_test/basic_op_capi.py
@@ -64,6 +64,7 @@ max_fd 4096
 conn_reconnect_millis 1000
 zk_reconnect_millis 1000
 zk_session_timeout_millis 10000
+local_proxy_query_timeout_millis 10000
         """ % self.cluster['cluster_name']
         old_cwd = os.path.abspath( os.getcwd() )
         os.chdir(util.capi_dir(0))

--- a/integration_test/test_basic_op.py
+++ b/integration_test/test_basic_op.py
@@ -98,6 +98,7 @@ max_fd 4096
 conn_reconnect_millis 1000
 zk_reconnect_millis 1000
 zk_session_timeout_millis 10000
+local_proxy_query_timeout_millis 10000
         """ % self.cluster['cluster_name']
         old_cwd = os.path.abspath( os.getcwd() )
         os.chdir(util.capi_dir(0))

--- a/tools/local_proxy/local_proxy.conf
+++ b/tools/local_proxy/local_proxy.conf
@@ -25,7 +25,7 @@ log_level INFO
 # log file prefix (default: "")
 # Using absolute or relative path is permitted.
 #
-# Example) 
+# Example)
 #       log_file_prefix "/home/username/log/local_proxy"
 #       log_file_prefix "local_proxy"
 log_file_prefix "local_proxy"
@@ -41,3 +41,6 @@ zk_reconnect_millis 1000
 
 # zookeeper session timeout (min:1000, default: 10000)
 zk_session_timeout_millis 10000
+
+# local proxy query timeout (min:1000, default: 3000)
+local_proxy_query_timeout_millis 3000


### PR DESCRIPTION
Because error code of CAPI is not handled properly in local_proxy,
clients of local_proxy may await replies indefinitely. To fix this,
local_proxy returns error msg if CAPI returns error code such as
timeout.

Additionally, local_proxy's query timeout is now configurable.