### PR TITLE
arcci win : fix C4013 and port isprint() to windows

### DIFF
--- a/api/arcci/arcci_be.c
+++ b/api/arcci/arcci_be.c
@@ -548,7 +548,7 @@ format_binary (char *buf, int bufsz, char *data, int data_size)
 
   for (i = 0; i < count; i++, bp++, dp++)
     {
-      if (isprint (*dp))
+      if (isprint ((unsigned char)*dp))
 	{
 	  *bp = *dp;
 	}

--- a/api/arcci/arcci_win_example/dummy_perf.c
+++ b/api/arcci/arcci_win_example/dummy_perf.c
@@ -16,6 +16,7 @@
 #include <stdarg.h>
 #include <signal.h>
 #include <assert.h>
+#include <process.h>
 
 #include "arcci.h"
 

--- a/api/arcci/sds.c
+++ b/api/arcci/sds.c
@@ -568,7 +568,7 @@ sds sdscatrepr(sds s, const char *p, size_t len) {
         case '\a': s = sdscatlen(s,"\\a",2); break;
         case '\b': s = sdscatlen(s,"\\b",2); break;
         default:
-            if (isprint(*p))
+            if (isprint((unsigned char)*p))
                 s = sdscatprintf(s,"%c",*p);
             else
                 s = sdscatprintf(s,"\\x%02x",(unsigned char)*p);

--- a/api/arcci/win32_wsiocp.h
+++ b/api/arcci/win32_wsiocp.h
@@ -74,10 +74,8 @@ typedef void fnDelCommState(void *apistate, aeCommState *sockState);
 int aeInitWinSock(void);
 void aeWinInit(void *state, HANDLE iocp, fnGetCommState *getCommState, fnDelCommState *delCommState);
 void aeWinCleanup();
-HANDLE aeWinGetIOCP();
-void aeWinSetIOCP(HANDLE iocph);
-void *aeWinGetIOCPState();
-void aeWinSetIOCPState(void *iocp_state);
+aeCommState *aeGetCommState(void *apistate, socket_t fd);
+void aeDelCommState(void *apistate, aeCommState *commState);
 
 #endif
 #endif

--- a/api/arcci/win32fixes.h
+++ b/api/arcci/win32fixes.h
@@ -318,6 +318,11 @@ int aeWinListen(socket_t sock, int backlog);
 socket_t aeWinAccept(socket_t fd, struct sockaddr *sa, socklen_t *len);
 int aeWinSocketConnect(socket_t fd, const struct sockaddr *sa, int len);
 
+HANDLE aeWinGetIOCP();
+void aeWinSetIOCP(HANDLE iocph);
+void *aeWinGetIOCPState();
+void aeWinSetIOCPState(void *iocp_state);
+
 int strerror_r(int err, char* buf, size_t buflen);
 char *wsa_strerror(int err);
 


### PR DESCRIPTION
* fix C4013 warning (function' undefined; assuming extern returning int)
* adjust isprint() to windows environment

Reviewed by @sanitysoon @cl9200 
