### PR TITLE
Fix protocol parsing bug in gateway and local proxy

### DIFF
--- a/gateway/gw_redis_parser.c
+++ b/gateway/gw_redis_parser.c
@@ -103,7 +103,7 @@ parseLine (sbuf_pos start, sbuf_pos last, sbuf_pos * ret_next,
   size_t offset;
   int ret;
 
-  ret = sbuf_memchr (start, last, '\r', &newline, &offset);
+  ret = sbuf_strchr (start, last, '\r', &newline, &offset);
   if (ret == ERR)
     {
       return PARSE_INSUFFICIENT_DATA;
@@ -186,7 +186,7 @@ inlineParser (ParseContext * ctx, sbuf_hdr * stream, sbuf ** query, sds * err)
 
   last = stream_last_pos (stream);
 
-  ret = sbuf_memchr (ctx->pos, last, '\n', &newline, &len);
+  ret = sbuf_strchr (ctx->pos, last, '\n', &newline, &len);
   if (ret == ERR)
     {
       if (sbuf_offset_len (ctx->pos, last) > PARSE_INLINE_MAX_SIZE)

--- a/gateway/gw_stream_buf.h
+++ b/gateway/gw_stream_buf.h
@@ -81,7 +81,7 @@ int sbuf_offset (sbuf_pos start, sbuf_pos last, size_t offset,
 ssize_t sbuf_offset_len (sbuf_pos start, sbuf_pos last);
 int sbuf_offset_char (sbuf_pos start, sbuf_pos last, size_t offset,
 		      char *ret_char);
-int sbuf_memchr (sbuf_pos start, sbuf_pos last, int c, sbuf_pos * ret_pos,
+int sbuf_strchr (sbuf_pos start, sbuf_pos last, int c, sbuf_pos * ret_pos,
 		 size_t * ret_offset);
 ssize_t sbuf_writev (sbuf ** bufv, ssize_t nbuf, int fd);
 void sbuf_reset_write_marker (sbuf * buf);

--- a/redis-2.8.8/tests/unit/protocol.tcl
+++ b/redis-2.8.8/tests/unit/protocol.tcl
@@ -79,7 +79,7 @@ start_server {tags {"protocol"}} {
             set test_time_limit 30
             while 1 {
                 if {[catch {
-                    puts -nonewline $s payload
+                    puts -nonewline $s $payload
                     flush $s
                     incr payload_size [string length $payload]
                 }]} {

--- a/redis-2.8.8/tests_gw/unit/protocol.tcl
+++ b/redis-2.8.8/tests_gw/unit/protocol.tcl
@@ -73,7 +73,7 @@ start_server {tags {"protocol"}} {
             set test_time_limit 30
             while 1 {
                 if {[catch {
-                    puts -nonewline $s payload
+                    puts -nonewline $s $payload
                     flush $s
                     incr payload_size [string length $payload]
                 }]} {

--- a/redis-2.8.8/tests_smr/unit/protocol.tcl
+++ b/redis-2.8.8/tests_smr/unit/protocol.tcl
@@ -71,7 +71,7 @@ start_server {tags {"protocol"}} {
             set test_time_limit 30
             while 1 {
                 if {[catch {
-                    puts -nonewline $s payload
+                    puts -nonewline $s $payload
                     flush $s
                     incr payload_size [string length $payload]
                 }]} {


### PR DESCRIPTION
* Fix inconsistency of redis and gateway's quoted inline protocol due to not using same character matching function "strchr()".
* Handle quoted inline protocol in local proxy

Reviewed-by: @sanitysoon @otheng03 