### PR TITLE
fix a bug in java client's decoder

### DIFF
--- a/api/java/src/main/java/com/navercorp/nbasearc/gcp/RedisDecoder.java
+++ b/api/java/src/main/java/com/navercorp/nbasearc/gcp/RedisDecoder.java
@@ -37,9 +37,9 @@ class RedisDecoder {
     private int lookasideBufferLength;
     
     RedisDecoder() {
-        // 16 : 11(bytes of a maximum integer) + 2(\r\n) + 1($ or *)
+        // 32 : 20(bytes of a maximum long) + 2(\r\n) + 1($ or *)
         //      and a power of 2
-        this.lookasideBuffer = new byte[16];
+        this.lookasideBuffer = new byte[32];
     }
 
     void getFrames(ByteBuf in, List<byte[]> out) {

--- a/api/java/src/test/java/com/navercorp/redis/cluster/gateway/GatewayClientTest.java
+++ b/api/java/src/test/java/com/navercorp/redis/cluster/gateway/GatewayClientTest.java
@@ -45,6 +45,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import redis.clients.jedis.BinaryClient.LIST_POSITION;
+import redis.clients.jedis.exceptions.JedisDataException;
 import redis.clients.jedis.Tuple;
 import redis.clients.util.SafeEncoder;
 
@@ -343,6 +344,20 @@ public class GatewayClientTest {
         gatewayClient.set(KEY_NUMBER, String.valueOf(VALUE_NUMBER));
         long incr = gatewayClient.incr(KEY_NUMBER);
         assertEquals(VALUE_NUMBER + 1, incr);
+    }
+
+    @Test
+    public void incrOverFlow() {
+        gatewayClient.set(KEY_NUMBER, String.valueOf(Long.MAX_VALUE - 1));
+        long value = gatewayClient.incr(KEY_NUMBER);
+        assertEquals(Long.MAX_VALUE, value);
+        
+        try {
+            gatewayClient.incr(KEY_NUMBER);
+            fail("incr operation is limited to 64 bit signed integers.");
+        } catch (GatewayException e) {
+            assertTrue(e.getCause() instanceof JedisDataException);
+        }
     }
 
     /**


### PR DESCRIPTION
* Bug fix : RedisDecoder couldn't parse long value reply, because the size of lookasideBuffer is too small to contain a long value.
* Add testcase

Reviewer : @sanitysoon 