### PR TITLE
fix a bug in batch_daemon

### DIFF
--- a/tools/batch_daemon/cm.py
+++ b/tools/batch_daemon/cm.py
@@ -67,7 +67,7 @@ def check_connection():
 
 def ping():
     try:
-        cm_conn.write('ping\r\n' % cluster_name)
+        cm_conn.write('ping\r\n')
         ret = cm_conn.read_until('\r\n', 3)
         json_data = json.loads(ret)
         if json_data['state'] != 'success' or json_data['msg'] != '+PONG':


### PR DESCRIPTION
* Bug: batch_damon's ping() always fails and reconnects to cm too frequently so that it wastes system resource.

Reviewer: @sanitysoon 