### PR TITLE
make gcov does not permit blocked commands

### DIFF
--- a/redis-3.2.9/src/arc_networking.c
+++ b/redis-3.2.9/src/arc_networking.c
@@ -376,7 +376,6 @@ process_command (client * c)
 	}
       cmdflags = c->smr->cmd->flags;
 
-#ifndef COVERAGE_TEST
       /* if the command is not permitted in cluster environment,
        * act as if this command does not exist */
       if (c->smr->cmd->flags & CMD_NOCLUSTER)
@@ -386,7 +385,6 @@ process_command (client * c)
 			       ("-ERR Unsupported Command\r\n", 26));
 	  cmdflags = 0;
 	}
-#endif
     }
 
   /* If this partition group is in OOM state, reply oom error message. 

--- a/redis-3.2.9/src/arc_server.c
+++ b/redis-3.2.9/src/arc_server.c
@@ -959,7 +959,10 @@ arcx_init_server_pre (void)
 // following commands are not permitted when arc.cluster_mode = 1
 // used commands are: ping, client list , lastsave , bgsave
 static const char *non_cluster_commands[] = {
-  "brpop", "brpoplpush", "blpop", "debug", "eval", "evalsha", "wait",
+#ifndef COVERAGE_TEST
+  "debug",
+#endif
+  "brpop", "brpoplpush", "blpop", "eval", "evalsha", "wait",
   "bgrewriteaof", "shutdown", "migrate", "move", "cluster", "asking",
   "restore-asking", "readonly", "readwrite", "psubscribe", "publish",
   "pubsub", "punsubscribe", "subscribe", "unsubscribe", "pfdebug",

--- a/redis-3.2.9/tests/nbase-arc/commands_generic.py
+++ b/redis-3.2.9/tests/nbase-arc/commands_generic.py
@@ -108,8 +108,11 @@ def do_commands(conn, GW=True):
         assert(resp >= 1)
 
         # |    DEBUG            | X | |
-        resp = r('DEBUG', 'object', key)
-        assert(resp.startswith('ERR Unsupported'))
+        if GW:
+            resp = r('DEBUG', 'object', key)
+            assert(resp.startswith('ERR Unsupported'))
+        else:
+            pass # integration test use 'debug'
 
         # |    DECR             | O | |
         r('set', key, 10)


### PR DESCRIPTION
1 exception for `debug` command that is used in integration test.
reviewer: @otheng03 @lynix94
