### PR TITLE
Java client: fix bugs

### DIFF
--- a/api/java/src/main/java/com/navercorp/redis/cluster/async/BackgroundPool.java
+++ b/api/java/src/main/java/com/navercorp/redis/cluster/async/BackgroundPool.java
@@ -18,8 +18,8 @@ package com.navercorp.redis.cluster.async;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.atomic.AtomicInteger;
+
+import com.navercorp.redis.cluster.util.DaemonThreadFactory;
 
 /**
  * @author jaehong.kim
@@ -42,7 +42,7 @@ public class BackgroundPool {
             if (this.pool != null) {
                 return this.pool;
             }
-            this.pool = Executors.newFixedThreadPool(this.poolSize, new BackgroundPoolFactory());
+            this.pool = Executors.newFixedThreadPool(this.poolSize, new DaemonThreadFactory(THREAD_PREFIX, true));
         }
         return this.pool;
     }
@@ -65,15 +65,5 @@ public class BackgroundPool {
         }
         sb.append("}");
         return sb.toString();
-    }
-
-    class BackgroundPoolFactory implements ThreadFactory {
-        private AtomicInteger count = new AtomicInteger(0);
-
-        public Thread newThread(Runnable runnable) {
-            final Thread t = new Thread(runnable, THREAD_PREFIX + count.getAndIncrement());
-            t.setDaemon(true);
-            return t;
-        }
     }
 }

--- a/api/java/src/main/java/com/navercorp/redis/cluster/gateway/Gateway.java
+++ b/api/java/src/main/java/com/navercorp/redis/cluster/gateway/Gateway.java
@@ -80,9 +80,11 @@ public class Gateway implements GatewayServerData {
         if (config.getDomainAddress() != null) {
             // domain
             addresses = GatewayAddress.asListFromDomain(config.getDomainAddress());
+            init(addresses);
         } else if (config.getIpAddress() != null) {
             // IP
             addresses = GatewayAddress.asList(config.getIpAddress());
+            init(addresses);
         } else if (config.isZkUsed()) {
             // zookeeper
             try {
@@ -92,17 +94,15 @@ public class Gateway implements GatewayServerData {
                 addresses = nodeWatcher.getGatewayAddress();
                 affinity = nodeWatcher.getGatewayAffinity();
             } catch (Exception e) {
-                log.error("[Gateway] Failed to connect CM. " + config.getZkAddress() + " - " + config.getClusterName(),
+                log.error("[Gateway] Failed to connect ZK. " + config.getZkAddress() + " - " + config.getClusterName(),
                         e);
             }
         }
 
-        if (addresses == null || addresses.size() == 0) {
+        if (servers.size() == 0) {
             destroy();
             throw new IllegalArgumentException("not found address " + config);
         }
-
-        init(addresses);
 
         this.selector = new GatewayServerSelector(config.getGatewaySelectorMethod());
     }
@@ -246,8 +246,6 @@ public class Gateway implements GatewayServerData {
 
     /**
      *
-     * @param partitionNumber the partitionNumber
-     * @param state the AffinityState
      * @return the server
      * @throws GatewayException the gateway exception
      */

--- a/api/java/src/main/java/com/navercorp/redis/cluster/gateway/Gateway.java
+++ b/api/java/src/main/java/com/navercorp/redis/cluster/gateway/Gateway.java
@@ -135,13 +135,14 @@ public class Gateway implements GatewayServerData {
                             config.getTimeoutMillisec(), config.getKeyspace(), gcp);
                     final int count = gatewayServer.preload(config.getClientSyncTimeUnitMillis(),
                             config.getConnectPerDelayMillis(), config.getPoolConfig());
+                    this.servers.put(address.getName(), gatewayServer);
+                    gatewayServer.setExist(true);
+                    log.info("[Gateway] Add gateway server " + gatewayServer);
+                    
                     this.gcp.addGw(address.getId(), address.getHost(), address.getPort(),
                             config.getPhysicalConnectionCount(), config.getPhysicalConnectionReconnectInterval())
                             .get(config.getTimeoutMillisec(), TimeUnit.MILLISECONDS);
-                    gatewayServer.setValid(count > 0);
-                    gatewayServer.setExist(true);
-                    this.servers.put(address.getName(), gatewayServer);
-                    log.info("[Gateway] Add gateway server " + gatewayServer);
+                    gatewayServer.setValid(true);
                 }
             } catch (Exception ex) {
                 log.error("[Gateway] Failed to reload " + address, ex);

--- a/api/java/src/main/java/com/navercorp/redis/cluster/gateway/GatewayServerClear.java
+++ b/api/java/src/main/java/com/navercorp/redis/cluster/gateway/GatewayServerClear.java
@@ -24,6 +24,8 @@ import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.navercorp.redis.cluster.util.DaemonThreadFactory;
+
 /**
  * @author jaehong.kim
  */
@@ -36,7 +38,8 @@ public class GatewayServerClear implements Runnable {
     private long lastRunTime = System.currentTimeMillis();
 
     public GatewayServerClear(final int periodSeconds) {
-        this.scheduler = Executors.newScheduledThreadPool(1);
+        this.scheduler = Executors.newScheduledThreadPool(1,
+                new DaemonThreadFactory("nbase-arc-gateway-server-clearer-", true));
         this.scheduler.scheduleAtFixedRate(this, periodSeconds, periodSeconds, TimeUnit.SECONDS);
     }
 

--- a/api/java/src/main/java/com/navercorp/redis/cluster/gateway/HealthCheckManager.java
+++ b/api/java/src/main/java/com/navercorp/redis/cluster/gateway/HealthCheckManager.java
@@ -24,6 +24,8 @@ import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.navercorp.redis.cluster.util.DaemonThreadFactory;
+
 /**
  * The Class HealthCheckManager.
  *
@@ -60,8 +62,10 @@ public class HealthCheckManager implements Runnable {
      */
     public HealthCheckManager(final GatewayServerData serverData, final int periodSeconds, final int threadSize) {
         this.serverData = serverData;
-        this.threadPool = Executors.newFixedThreadPool(threadSize);
-        this.scheduler = Executors.newScheduledThreadPool(1);
+        this.threadPool = Executors.newFixedThreadPool(threadSize,
+                new DaemonThreadFactory("nbase-arc-gateway-healthchecker-", true));
+        this.scheduler = Executors.newScheduledThreadPool(1,
+                new DaemonThreadFactory("nbase-arc-gateway-healthcheck-scheduler-", true));
         this.scheduler.scheduleAtFixedRate(this, periodSeconds, periodSeconds, TimeUnit.SECONDS);
     }
 

--- a/api/java/src/main/java/com/navercorp/redis/cluster/gateway/NodeWatcher.java
+++ b/api/java/src/main/java/com/navercorp/redis/cluster/gateway/NodeWatcher.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -30,6 +29,8 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.navercorp.redis.cluster.util.DaemonThreadFactory;
+
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
@@ -60,7 +61,8 @@ public class NodeWatcher implements Watcher {
     private GatewayServerData gatewayServerData;
     private ObjectMapper objectMapper = new ObjectMapper();
 
-    final ExecutorService connectExecutor = Executors.newSingleThreadExecutor();
+    final ExecutorService connectExecutor = Executors.newSingleThreadExecutor(
+            new DaemonThreadFactory("nbase-arc-zookeeper-connector-", true));
     private final AtomicBoolean shutdown = new AtomicBoolean(false);
 
     public NodeWatcher(GatewayServerData gatewayServerData) {

--- a/api/java/src/main/java/com/navercorp/redis/cluster/gateway/NodeWatcher.java
+++ b/api/java/src/main/java/com/navercorp/redis/cluster/gateway/NodeWatcher.java
@@ -20,8 +20,14 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.zookeeper.KeeperException;
@@ -47,13 +53,15 @@ public class NodeWatcher implements Watcher {
 
     private final Logger log = LoggerFactory.getLogger(NodeWatcher.class);
 
-    final CountDownLatch connLatcher = new CountDownLatch(1);
+    private CountDownLatch connLatcher;
 
     private ZooKeeper zk;
     private GatewayConfig config;
     private GatewayServerData gatewayServerData;
     private ObjectMapper objectMapper = new ObjectMapper();
 
+    final ExecutorService connectExecutor = Executors.newSingleThreadExecutor();
+    private final AtomicBoolean shutdown = new AtomicBoolean(false);
 
     public NodeWatcher(GatewayServerData gatewayServerData) {
         this.gatewayServerData = gatewayServerData;
@@ -63,13 +71,40 @@ public class NodeWatcher implements Watcher {
         this.config = config;
     }
 
-    public void start() throws IOException, InterruptedException, KeeperException {
+    public void start() throws InterruptedException, ExecutionException, TimeoutException {
         log.info("[NodeWatcher] Starting {} {}", config.getZkAddress(), buildGatewayPath());
 
-        this.zk = new ZooKeeper(config.getZkAddress(), config.getZkSessionTimeout(), this);
-        this.connLatcher.await(config.getZkConnectTimeout(), TimeUnit.MILLISECONDS); // if not yet connected to ZooKeeper, wait
+        this.connLatcher = new CountDownLatch(1);
+        connectExecutor.submit(zkConnector);
+        this.connLatcher.await(config.getZkConnectTimeout(), TimeUnit.MILLISECONDS);
     }
 
+    private Runnable zkConnector = new Runnable() {
+        @Override
+        public void run() {
+            int retryDelay = 500;
+
+            while (shutdown.get() == false) {
+                try {
+                    log.warn("[NodeWatcher] try to connect to zookeeper.");
+                    zk = new ZooKeeper(config.getZkAddress(), config.getZkSessionTimeout(), NodeWatcher.this);
+                    return;
+                } catch (IOException e) {
+                    log.warn("[NodeWatcher] failed to connect to zookeeper.", e);
+                    retryDelay *= 2;
+                    if (retryDelay > 8000)
+                        retryDelay = 8000;
+                }
+                
+                try {
+                    Thread.sleep(retryDelay);
+                } catch (InterruptedException e) {
+                    log.error("[NodeWatcher] failed to sleep for retryDelay.", e);
+                }
+            }
+        }
+    };
+    
     String buildGatewayPath() {
         StringBuilder sb = new StringBuilder();
         sb.append(ZK_CLUSTER_PATH).append("/").append(config.getClusterName()).append(ZK_GATEWAY);
@@ -144,6 +179,9 @@ public class NodeWatcher implements Watcher {
     public void stop() {
         log.info("[NodeWatcher] Stop");
 
+        shutdown.set(true);
+        connectExecutor.shutdown();
+        
         if (zk == null) {
             return;
         }
@@ -156,7 +194,7 @@ public class NodeWatcher implements Watcher {
     }
 
     /**
-     * @param event the event
+     * @param event
      * @see org.apache.zookeeper.Watcher#process(org.apache.zookeeper.WatchedEvent)
      */
     public void process(WatchedEvent event) {
@@ -168,10 +206,21 @@ public class NodeWatcher implements Watcher {
             switch (event.getState()) {
                 case SyncConnected:
                     log.debug("[NodeWatcher] SyncConnected");
+                    reloadGatewaylist();
+                    reloadGatewayAffinity();
                     this.connLatcher.countDown();
                     break;
+                case Expired:
+                    log.debug("[NodeWatcher] Expired");
+                    try {
+                        zk.close();
+                    } catch (InterruptedException e) {
+                        log.error("[NodeWatcher] failed to clean up ZooKeeper");
+                    }
+                    connectExecutor.submit(zkConnector);
+                    break;
                 default:
-
+                    break;
             }
         } else if (event.getType() == Event.EventType.NodeChildrenChanged) {
             log.debug("[NodeWatcher] NodeChildrenChanged");

--- a/api/java/src/main/java/com/navercorp/redis/cluster/util/DaemonThreadFactory.java
+++ b/api/java/src/main/java/com/navercorp/redis/cluster/util/DaemonThreadFactory.java
@@ -1,0 +1,21 @@
+package com.navercorp.redis.cluster.util;
+
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class DaemonThreadFactory implements ThreadFactory {
+    private AtomicInteger count = new AtomicInteger(0);
+    private final String threadNamePrefix;
+    private final boolean daemon;
+
+    public DaemonThreadFactory(String threadNamePrefix, boolean daemon) {
+        this.threadNamePrefix = threadNamePrefix;
+        this.daemon = daemon;
+    }
+    
+    public Thread newThread(Runnable runnable) {
+        final Thread t = new Thread(runnable, threadNamePrefix + count.getAndIncrement());
+        t.setDaemon(daemon);
+        return t;
+    }
+}


### PR DESCRIPTION
* Fix bugs in java client
  * Session expired events are ignored.
    * Retry to connect to zookeeper when session is expired
  * Initially crashed gateways could not be handled normally when gateway-lookup-info is changed.

Reviewers: @sanitysoon @jaehong-kim 