### PR TITLE
fix typo

### DIFF
--- a/doc/gateway.md
+++ b/doc/gateway.md
@@ -4,13 +4,13 @@ Gateway is located between clients and Redis processes and provides a transparen
 The nbase-arc gateway has following notable features.
 
 ### High performance
-The performance of the gateway is equal or higher than other similar open source products. This is due to zero-copy buffer management, scatter/gather I/O, reducing malloc overhead by using fixed size buffer with memory pool, and smart pipelining of multiple client quries. See below benchmark test.
+The performance of the gateway is equal or higher than other similar open source products. This is due to zero-copy buffer management, scatter/gather I/O, reducing malloc overhead by using fixed size buffer with memory pool, and smart pipelining of multiple client queries. See below benchmark test.
 
 ### Seamless integration with the configuration master and tools
 Gateway provides administrative commands such as adding/removing Redis processes and change the key distribution information of a cluster. These commands along with configuration master allow the reconfigurations of a cluster can be performed seamlessly on production environment. The reconfiguration of a cluster includes moving processes between servers, upgrading components, scaling in/out cluster, and etc. 
 
 ### Structure
-Gateway is composed of multiple worker threads and single master thread. Each thread runs non-blocking eventloop. Master thread allocates client connections to the worker threads and excutes admin commands. Each worker thread runs indepedently and processes queries from allocated clients.
+Gateway is composed of multiple worker threads and single master thread. Each thread runs non-blocking eventloop. Master thread allocates client connections to the worker threads and excutes admin commands. Each worker thread runs independently and processes queries from allocated clients.
 
 ### Benchmark
 


### PR DESCRIPTION
nbase-arc 사용을 위해서 문서를 읽던 중 오타를 발견하여 커밋드립니다.

quries ->queries
indepedently -> independently