### PR TITLE
hot-fix for java-client-1.5.1

### DIFF
--- a/api/java/pom.xml
+++ b/api/java/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.navercorp</groupId>
     <artifactId>nbase-arc-java-client</artifactId>
     <packaging>jar</packaging>
-    <version>1.5.1</version>
+    <version>1.5.1.1</version>
     <name>nbase-arc java client</name>
     <description>nbase-arc java client</description>
     <url>https://github.com/naver/nbase-arc</url>

--- a/api/java/src/main/java/com/navercorp/nbasearc/gcp/GatewayConnectionPool.java
+++ b/api/java/src/main/java/com/navercorp/nbasearc/gcp/GatewayConnectionPool.java
@@ -233,11 +233,11 @@ public class GatewayConnectionPool {
         // Random selection
         List<Gateway> candidates = gatewayList.get();
         int index = roundGatewayIndex.incrementAndGet() % candidates.size();
+        if (index < 0) {
+            index = index + candidates.size();
+        }
         for (int i = 0; i < Math.min(3, candidates.size()); i++) {
-            index = Math.abs(index + 1);
-            if (index >= candidates.size()) {
-                index = 0;
-            }
+            index = (index + 1) % candidates.size();
             
             Gateway gw = candidates.get(index);
             if (gw.getActive() > 0) {

--- a/api/java/src/main/java/com/navercorp/redis/cluster/async/BackgroundPool.java
+++ b/api/java/src/main/java/com/navercorp/redis/cluster/async/BackgroundPool.java
@@ -18,8 +18,8 @@ package com.navercorp.redis.cluster.async;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.atomic.AtomicInteger;
+
+import com.navercorp.redis.cluster.util.DaemonThreadFactory;
 
 /**
  * @author jaehong.kim
@@ -42,7 +42,7 @@ public class BackgroundPool {
             if (this.pool != null) {
                 return this.pool;
             }
-            this.pool = Executors.newFixedThreadPool(this.poolSize, new BackgroundPoolFactory());
+            this.pool = Executors.newFixedThreadPool(this.poolSize, new DaemonThreadFactory(THREAD_PREFIX, true));
         }
         return this.pool;
     }
@@ -65,15 +65,5 @@ public class BackgroundPool {
         }
         sb.append("}");
         return sb.toString();
-    }
-
-    class BackgroundPoolFactory implements ThreadFactory {
-        private AtomicInteger count = new AtomicInteger(0);
-
-        public Thread newThread(Runnable runnable) {
-            final Thread t = new Thread(runnable, THREAD_PREFIX + count.getAndIncrement());
-            t.setDaemon(true);
-            return t;
-        }
     }
 }

--- a/api/java/src/main/java/com/navercorp/redis/cluster/gateway/Gateway.java
+++ b/api/java/src/main/java/com/navercorp/redis/cluster/gateway/Gateway.java
@@ -80,9 +80,11 @@ public class Gateway implements GatewayServerData {
         if (config.getDomainAddress() != null) {
             // domain
             addresses = GatewayAddress.asListFromDomain(config.getDomainAddress());
+            init(addresses);
         } else if (config.getIpAddress() != null) {
             // IP
             addresses = GatewayAddress.asList(config.getIpAddress());
+            init(addresses);
         } else if (config.isZkUsed()) {
             // zookeeper
             try {
@@ -92,17 +94,15 @@ public class Gateway implements GatewayServerData {
                 addresses = nodeWatcher.getGatewayAddress();
                 affinity = nodeWatcher.getGatewayAffinity();
             } catch (Exception e) {
-                log.error("[Gateway] Failed to connect CM. " + config.getZkAddress() + " - " + config.getClusterName(),
+                log.error("[Gateway] Failed to connect ZK. " + config.getZkAddress() + " - " + config.getClusterName(),
                         e);
             }
         }
 
-        if (addresses == null || addresses.size() == 0) {
+        if (servers.size() == 0) {
             destroy();
             throw new IllegalArgumentException("not found address " + config);
         }
-
-        init(addresses);
 
         this.selector = new GatewayServerSelector(config.getGatewaySelectorMethod());
     }

--- a/api/java/src/main/java/com/navercorp/redis/cluster/gateway/Gateway.java
+++ b/api/java/src/main/java/com/navercorp/redis/cluster/gateway/Gateway.java
@@ -135,13 +135,14 @@ public class Gateway implements GatewayServerData {
                             config.getTimeoutMillisec(), config.getKeyspace(), gcp);
                     final int count = gatewayServer.preload(config.getClientSyncTimeUnitMillis(),
                             config.getConnectPerDelayMillis(), config.getPoolConfig());
+                    this.servers.put(address.getName(), gatewayServer);
+                    gatewayServer.setExist(true);
+                    log.info("[Gateway] Add gateway server " + gatewayServer);
+                    
                     this.gcp.addGw(address.getId(), address.getHost(), address.getPort(),
                             config.getPhysicalConnectionCount(), config.getPhysicalConnectionReconnectInterval())
                             .get(config.getTimeoutMillisec(), TimeUnit.MILLISECONDS);
-                    gatewayServer.setValid(count > 0);
-                    gatewayServer.setExist(true);
-                    this.servers.put(address.getName(), gatewayServer);
-                    log.info("[Gateway] Add gateway server " + gatewayServer);
+                    gatewayServer.setValid(true);
                 }
             } catch (Exception ex) {
                 log.error("[Gateway] Failed to reload " + address, ex);

--- a/api/java/src/main/java/com/navercorp/redis/cluster/gateway/GatewayServerClear.java
+++ b/api/java/src/main/java/com/navercorp/redis/cluster/gateway/GatewayServerClear.java
@@ -24,6 +24,8 @@ import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.navercorp.redis.cluster.util.DaemonThreadFactory;
+
 /**
  * @author jaehong.kim
  */
@@ -36,7 +38,8 @@ public class GatewayServerClear implements Runnable {
     private long lastRunTime = System.currentTimeMillis();
 
     public GatewayServerClear(final int periodSeconds) {
-        this.scheduler = Executors.newScheduledThreadPool(1);
+        this.scheduler = Executors.newScheduledThreadPool(1,
+                new DaemonThreadFactory("nbase-arc-gateway-server-clearer-", true));
         this.scheduler.scheduleAtFixedRate(this, periodSeconds, periodSeconds, TimeUnit.SECONDS);
     }
 

--- a/api/java/src/main/java/com/navercorp/redis/cluster/gateway/HealthCheckManager.java
+++ b/api/java/src/main/java/com/navercorp/redis/cluster/gateway/HealthCheckManager.java
@@ -24,6 +24,8 @@ import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.navercorp.redis.cluster.util.DaemonThreadFactory;
+
 /**
  * The Class HealthCheckManager.
  *
@@ -60,8 +62,10 @@ public class HealthCheckManager implements Runnable {
      */
     public HealthCheckManager(final GatewayServerData serverData, final int periodSeconds, final int threadSize) {
         this.serverData = serverData;
-        this.threadPool = Executors.newFixedThreadPool(threadSize);
-        this.scheduler = Executors.newScheduledThreadPool(1);
+        this.threadPool = Executors.newFixedThreadPool(threadSize,
+                new DaemonThreadFactory("nbase-arc-gateway-healthchecker-", true));
+        this.scheduler = Executors.newScheduledThreadPool(1,
+                new DaemonThreadFactory("nbase-arc-gateway-healthcheck-scheduler-", true));
         this.scheduler.scheduleAtFixedRate(this, periodSeconds, periodSeconds, TimeUnit.SECONDS);
     }
 

--- a/api/java/src/main/java/com/navercorp/redis/cluster/gateway/NodeWatcher.java
+++ b/api/java/src/main/java/com/navercorp/redis/cluster/gateway/NodeWatcher.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -30,6 +29,8 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.navercorp.redis.cluster.util.DaemonThreadFactory;
+
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
@@ -60,7 +61,8 @@ public class NodeWatcher implements Watcher {
     private GatewayServerData gatewayServerData;
     private ObjectMapper objectMapper = new ObjectMapper();
 
-    final ExecutorService connectExecutor = Executors.newSingleThreadExecutor();
+    final ExecutorService connectExecutor = Executors.newSingleThreadExecutor(
+            new DaemonThreadFactory("nbase-arc-zookeeper-connector-", true));
     private final AtomicBoolean shutdown = new AtomicBoolean(false);
 
     public NodeWatcher(GatewayServerData gatewayServerData) {

--- a/api/java/src/main/java/com/navercorp/redis/cluster/util/DaemonThreadFactory.java
+++ b/api/java/src/main/java/com/navercorp/redis/cluster/util/DaemonThreadFactory.java
@@ -1,0 +1,21 @@
+package com.navercorp.redis.cluster.util;
+
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class DaemonThreadFactory implements ThreadFactory {
+    private AtomicInteger count = new AtomicInteger(0);
+    private final String threadNamePrefix;
+    private final boolean daemon;
+
+    public DaemonThreadFactory(String threadNamePrefix, boolean daemon) {
+        this.threadNamePrefix = threadNamePrefix;
+        this.daemon = daemon;
+    }
+    
+    public Thread newThread(Runnable runnable) {
+        final Thread t = new Thread(runnable, threadNamePrefix + count.getAndIncrement());
+        t.setDaemon(daemon);
+        return t;
+    }
+}


### PR DESCRIPTION
Support hot-fix for java-clien-1.5.1 because 1.5.1 is the last version using old versions of spring and jedis.
(spring-framework 3.2.8 and spring-data-redis 1.3.5, and jedis 2.7.2)