### PR TITLE
bugfix: playdump fails when a written object size exceeds INT_MAX

### DIFF
--- a/redis-3.2.9/src/arc_cluster_util.c
+++ b/redis-3.2.9/src/arc_cluster_util.c
@@ -263,7 +263,8 @@ static void
 playdump_write_handler (aeEventLoop * el, int fd, void *data, int mask)
 {
   struct dumpState *ds = (struct dumpState *) data;
-  int ret = 0, nw, len;
+  int ret = 0, nw;
+  off_t len;
   UNUSED (mask);
 
 


### PR DESCRIPTION
reviewers: @otheng03 , @lynix94 