### PR TITLE
java: change dependency jars to the recommended versions

### DIFF
--- a/api/java/pom.xml
+++ b/api/java/pom.xml
@@ -54,10 +54,11 @@
 
     <properties>
         <java.version>1.6</java.version>
-        <org.springframework.version>4.3.9.RELEASE</org.springframework.version>
+        <org.springframework.version>4.3.18.RELEASE</org.springframework.version>
         <spring-data-redis.version>1.8.4.RELEASE</spring-data-redis.version>
         <jedis.version>2.9.0</jedis.version>
         <guava.version>19.0</guava.version>
+        <jackson.version>2.8.11.1</jackson.version>
     </properties>
 
     <dependencies>
@@ -85,14 +86,8 @@
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-            <version>2.6.4</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.6.4</version>
+            <version>${jackson.version}</version>
         </dependency>
 
         <dependency>

--- a/confmaster/pom.xml
+++ b/confmaster/pom.xml
@@ -7,7 +7,7 @@
 
     <properties>
         <encoding>UTF-8</encoding>
-        <spring.version>4.1.8.RELEASE</spring.version>
+        <spring.version>4.3.18.RELEASE</spring.version>
         <slf4j.version>1.5.8</slf4j.version>
         <log4j.version>1.2.14</log4j.version>
         <jackson.version>1.8.10</jackson.version>

--- a/confmaster/src/test/java/com/navercorp/nbasearc/confmaster/server/command/CommandTest.java
+++ b/confmaster/src/test/java/com/navercorp/nbasearc/confmaster/server/command/CommandTest.java
@@ -42,6 +42,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.MockitoAnnotations;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.convert.ConversionFailedException;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -867,10 +868,8 @@ public class CommandTest extends BasicSetting {
                 formatReply(result, null));
 
         result = doCommand("op_wf " + clusterName + " " + pgName + " AA invalid forced");
-        assertEquals(
-                "{\"state\":\"error\",\"msg\":\"-ERR Failed to convert from type java.lang.String to type boolean for value 'invalid';"
-                        + " nested exception is java.lang.IllegalArgumentException: Invalid boolean value 'invalid'\"}\r\n",
-                formatReply(result, null));
+        assertTrue(formatReply(result, null).startsWith("{\"state\":\"error\""));
+        assertEquals(ConversionFailedException.class, result.getExceptions().get(0).getClass());
         
         result = doCommand("op_wf " + clusterName + " " + pgName + " AA false not-forced");
         assertEquals(


### PR DESCRIPTION
* Security alerts recommend to change the version of dependency jars
  * spring framework to 4.3.17 or above
  * jackson 2.8.11.1 or above

Reviewer: @sanitysoon @lynix94 