### PR TITLE
SMR bug fixes and enhancements

### DIFF
--- a/api/java/src/test/resources/test.properties
+++ b/api/java/src/test/resources/test.properties
@@ -1,4 +1,4 @@
-host=x.x.x.x
-port=999
-zkAddress=x.x.x.x:1281
-clusterName=xxx
+host=127.0.0.1
+port=6000
+zkAddress=127.0.0.1:2181
+clusterName=test

--- a/integration_test/redis_sock.py
+++ b/integration_test/redis_sock.py
@@ -49,11 +49,13 @@ class RedisClient:
         elif prefix == "-": # error
             return False, data
         elif prefix == ":": # integer reply
-            len = int(data)
-            return True, len
+            length = int(data)
+            return True, length
         elif prefix == "$": # bulk reply
-            len = int(data)
-            nextchunk = self.io_read(len+2)
+            length = int(data)
+            if length == -1:
+                return True, None
+            nextchunk = self.io_read(length+2)
 	    return True, nextchunk[:-2]
         elif prefix == "*": # multibulk reply
             count = int(data)

--- a/integration_test/test_clusterutil.py
+++ b/integration_test/test_clusterutil.py
@@ -119,7 +119,9 @@ class TestClusterUtil(unittest.TestCase):
             if first != True:
                 mb = (last - prev) / 1024 / 1024
                 util.log("Network usage: %dMB/s, Limit: %dMB/s" % (mb, limit_mb))
-                self.assertTrue(mb <= limit_mb*1.3)
+                # proxy server checks file size via pipe line of nc and tees
+                # add marginal bandwidth (e.g. /proc/sys/fs/pipe-max-size --> 1M) to the assertion
+                self.assertTrue(mb <= (limit_mb + 10))
             first = False
             prev = last
 

--- a/integration_test/test_denyoom.py
+++ b/integration_test/test_denyoom.py
@@ -1,0 +1,81 @@
+#
+# Copyright 2015 Naver Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import unittest
+import testbase
+import util
+import redis_sock
+import config
+import default_cluster
+
+
+# NOTE
+# oom state persistence test is done by hand (hard to automate in this test framework)
+#
+class TestDenyOOM( unittest.TestCase ):
+    cluster = config.clusters[0]
+    leader_cm = config.clusters[0]['servers'][0]
+
+    @classmethod
+    def setUpClass(cls):
+        cls.conf_checker = default_cluster.initialize_starting_up_smr_before_redis( cls.cluster )
+        assert cls.conf_checker != None, 'failed to initialize cluster'
+
+    @classmethod
+    def tearDownClass( cls ):
+        testbase.defaultTearDown(cls)
+
+    def setUp( self ):
+        util.set_process_logfile_prefix( 'TestDenyOOM_%s' % self._testMethodName )
+        server = self.cluster['servers'][0]
+        self.redis = redis_sock.RedisClient(server['ip'], server['redis_port'])
+
+    def tearDown( self ):
+        if self.redis != None:
+            self.redis.close()
+        return 0
+
+    def check_oom(self, is_oom = False):
+        m,s1,s2 = util.get_mss(self.cluster)
+        mr = redis_sock.RedisClient(m['ip'], m['redis_port'])
+        sr = redis_sock.RedisClient(s1['ip'], s1['redis_port'])
+        try:
+            ok, data = mr.do_request("get nosuchkey_check_oom\r\n")
+            assert(ok), ok
+            ok, data = sr.do_request("get nosuchkey_check_oom\r\n")
+            assert(ok), ok
+            expected_ok = not is_oom
+            ok, data = mr.do_request("set nosuchkey_check_oom 100\r\n")
+            assert(ok == expected_ok), (ok, data)
+            ok, data = sr.do_request("set nosuchkey_check_oom 100\r\n")
+            assert(ok == expected_ok), (ok, data)
+        finally:
+            if mr != None:
+                mr.close()
+            if sr != None:
+                sr.close()
+
+    def test_basic ( self ):
+        util.print_frame()
+        redis = self.redis
+        # set oom
+        ok, resp = redis.do_request('deny-oom 1\r\n')
+        assert(resp == 'OK'), resp
+        self.check_oom(True)
+        # reset oom
+        ok, resp = redis.do_request('deny-oom 0\r\n')
+        assert(resp == 'OK'), resp
+        self.check_oom(False)

--- a/redis/src/arc_networking.c
+++ b/redis/src/arc_networking.c
@@ -396,7 +396,9 @@ process_command (client * c)
    *
    * we can use mstime of local machine for checking oom, 
    * because message is not inserted to smr log, yet. */
-  if (mstime () < arc.smr_oom_until && (cmdflags & CMD_DENYOOM))
+  if ((cmdflags & CMD_DENYOOM) &&
+      (arc.pg_deny_oom
+       || (arc.smr_oom_until > 0 && mstime () < arc.smr_oom_until)))
     {
       incrRefCount (shared.oomerr);
       replace_parsed_args (c, shared.oomerr);

--- a/redis/src/arc_server.c
+++ b/redis/src/arc_server.c
@@ -246,6 +246,7 @@ init_config (void)
   arc.mem_limit_active_kb = 0;
   arc.mem_max_allowed_byte = 0;
   arc.mem_hard_limit_kb = 0;
+  arc.pg_deny_oom = 0;
 
   /* Local ip check */
   arc.local_ip_addrs = arcx_get_local_ip_addrs ();	//TODO why here?
@@ -1192,5 +1193,25 @@ crc16Command (client * c)
   addReply (c, new);
   addReply (c, shared.crlf);
 }
+
+void
+denyoomCommand (client * c)
+{
+  long val = 0;
+
+  if (getLongFromObjectOrReply (c, c->argv[1], &val, "invalid deny-oom value")
+      != C_OK)
+    {
+      return;
+    }
+  if (val != 0 && val != 1)
+    {
+      addReplyError (c, "invalid deny-oom value");
+      return;
+    }
+  arc.pg_deny_oom = (int) val;
+  addReply (c, shared.ok);
+}
+
 
 #endif

--- a/redis/src/arc_server.h
+++ b/redis/src/arc_server.h
@@ -185,6 +185,7 @@ struct arcServer
   unsigned long mem_limit_active_kb;
   unsigned long mem_max_allowed_byte;
   unsigned long mem_hard_limit_kb;
+  int pg_deny_oom;
 
   /* local ip check */
   char **local_ip_addrs;
@@ -262,6 +263,8 @@ extern int arc_config_cmp_load (int argc, sds * argv, char **err_ret);
     shared.db_migrate_slot = createStringObject("\001\002\003db_migrate_slot", 18);    \
     /* key for saving migration state */                                               \
     shared.db_migclear_slot = createStringObject("\001\002\003db_migclear_slot", 19);  \
+    /* PG deny oom state */                                                            \
+    shared.pg_deny_oom = createStringObject("\001\002\003pg_deny_oom", 14);            \
     /* Reserved object in order to reply through replication stream. */                \
     shared.addreply_through_smr = createStringObject("dummyobject_notused", 19);       \
 } while(0)
@@ -305,12 +308,13 @@ extern int arc_config_cmp_load (int argc, sds * argv, char **err_ret);
     {"s3expire",s3expireCommand,4,"w",0,NULL,2,2,1,0,0},              \
     {"s3rem",s3remCommand,3,"w",0,NULL,2,2,1,0,0},                    \
     {"s3mrem",s3mremCommand,-4,"w",0,NULL,2,2,1,0,0},                 \
-    {"s3gc",s3gcCommand,2,"w",0,NULL,0,0,0,0,0},                       \
+    {"s3gc",s3gcCommand,2,"w",0,NULL,0,0,0,0,0},                      \
     {"checkpoint",checkpointCommand,2,"ars",0,NULL,0,0,0,0,0},        \
     {"migstart",migstartCommand,2,"aw",0,NULL,0,0,0,0,0},             \
     {"migend",migendCommand,1,"aw",0,NULL,0,0,0,0,0},                 \
     {"migconf",migconfCommand,-2,"aw",0,NULL,0,0,0,0,0},              \
     {"migpexpireat",migpexpireatCommand,3,"w",0,NULL,1,1,1,0,0},      \
+    {"deny-oom",denyoomCommand,2,"aw",0,NULL,0,0,0,0,0},              \
     {"crc16",crc16Command,3,"wm",0,NULL,1,1,1,0,0},                   \
     {"bping",bpingCommand,1,"r",0,NULL,0,0,0,0,0},                    \
     {"quit",quitCommand,1,"r",0,NULL,0,0,0,0,0}                       \
@@ -344,6 +348,7 @@ extern int arc_handle_command_rewrite (client * c);
 // return 1 if handled, 0 otherwise
 extern int arc_debug_hook (client * c);
 extern void crc16Command (client * c);
+extern void denyoomCommand (client * c);
 
 /* arc_networking.c */
 extern void arc_smrc_create (client * c);

--- a/redis/src/server.h
+++ b/redis/src/server.h
@@ -633,7 +633,7 @@ struct sharedObjectsStruct {
     *unsubscribebulk, *psubscribebulk, *punsubscribebulk, *del, *rpop, *lpop,
     *lpush, *emptyscan, *minstring, *maxstring,
 #ifdef NBASE_ARC
-    *db_version, *db_smr_mstime, *db_migrate_slot, *db_migclear_slot, *addreply_through_smr,
+    *db_version, *db_smr_mstime, *db_migrate_slot, *db_migclear_slot, *addreply_through_smr, *pg_deny_oom,
 #endif
     *select[PROTO_SHARED_SELECT_CMDS],
     *integers[OBJ_SHARED_INTEGERS],

--- a/smr/replicator/bio.c
+++ b/smr/replicator/bio.c
@@ -216,7 +216,9 @@ sync_proc (bioState * bs)
 
   while (log_base_seq > sync_base_seq)
     {
-      ret = smrlog_sync_maps (rep->smrlog, bs->src->addr, bs->sync->addr);
+      ret =
+	smrlog_sync_maps (rep->smrlog, bs->src->addr, SMR_LOG_FILE_DATA_SIZE,
+			  bs->sync->addr);
       if (ret < 0)
 	{
 	  return ERR_LINE;
@@ -258,11 +260,14 @@ sync_proc (bioState * bs)
 	}
     }
 
-  ret = smrlog_sync_maps (rep->smrlog, bs->src->addr, bs->sync->addr);
+  ret =
+    smrlog_sync_maps (rep->smrlog, bs->src->addr,
+		      (int) (log_seq - log_base_seq), bs->sync->addr);
   if (ret < 0)
     {
       return ERR_LINE;
     }
+
   from = (int) (bs->sync_seq - log_base_seq);
   to = (int) (log_seq - log_base_seq);
   assert (from <= to);

--- a/smr/replicator/common.h
+++ b/smr/replicator/common.h
@@ -430,6 +430,8 @@ struct smrReplicator_
   localConn *local_client;	// local client
   /* salve only */
   masterConn *master;		// (slave) master replicator
+  /* client */
+  long long last_timestamp;	// last timestamp that master replicator issues (non decreasing)
   /* master only */
   dlisth clients;		// list haed for clientConn
   volatile int num_slaves;	// number of current slaves
@@ -615,4 +617,20 @@ extern void applog_leave_session (smrReplicator * rep);
 
 extern void log_msg (smrReplicator * rep, int level, char *fmt, ...);
 extern char *get_command_string (char cmd);
+
+
+//borrowed from redis/src/config.h
+#if (__i386 || __amd64 || __powerpc__) && __GNUC__
+#define GNUC_VERSION (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
+#if (defined(__GLIBC__) && defined(__GLIBC_PREREQ))
+#if (GNUC_VERSION >= 40100 && __GLIBC_PREREQ(2, 6))
+#define HAVE_MEMFENCE
+#endif
+#endif
+#endif
+
+#if !defined(HAVE_MEMFENCE)
+#error "Need glibc and gcc version that supports __sync_synchronize"
+#endif
+
 #endif

--- a/smr/replicator/common.h
+++ b/smr/replicator/common.h
@@ -421,6 +421,7 @@ struct smrReplicator_
   smrAtomicSeq cron_est_min_seq;	// minimun sequence estimated by server cron (log file boundary)
   smrAtomicSeq mig_seq;		// upto which migration log caught-up
   int log_delete_gap;		// checkpointed log delete gap in seconds from now
+  smrAtomicSeq log_delete_seq;	// checkpointed log delete sequence
   /* general */
   short nid;			// node id of this replicator
   struct timeval stat_time;	// stat report time

--- a/smr/replicator/smrmp.c
+++ b/smr/replicator/smrmp.c
@@ -60,7 +60,7 @@ smrmp_parse_msg (char *buf, int buf_sz, char ***rtok)
 
   while ((token = strtok_r (NULL, DELIM, &save_ptr)) != NULL)
     {
-      if (idx > tsz)
+      if (idx >= tsz)
 	{
 	  char **new_tokens;
 

--- a/smr/smr/log_addr.c
+++ b/smr/smr/log_addr.c
@@ -465,11 +465,15 @@ smrlog_sync (smrLog * handle, smrLogAddr * addr)
   return 0;
 }
 
+//
+// Sync src_addr data to dest_addr.  Note that this function assumes
+// (1) non-concurrent access to dest_addr
+// (2) data upto src + off is valid
+//
 int
-smrlog_sync_maps (smrLog * handle, smrLogAddr * src_addr,
+smrlog_sync_maps (smrLog * handle, smrLogAddr * src_addr, int src_off,
 		  smrLogAddr * dest_addr)
 {
-  int src_off;
   int dest_off;
   char *bp;
   int size;
@@ -485,13 +489,6 @@ smrlog_sync_maps (smrLog * handle, smrLogAddr * src_addr,
   if (src_addr == dest_addr)
     {
       return 0;
-    }
-
-  src_off = addr_offset (src_addr);
-  if (src_off < 0)
-    {
-      ERRNO_POINT ();
-      return -1;
     }
 
   dest_off = addr_offset (dest_addr);

--- a/smr/smr/log_internal.h
+++ b/smr/smr/log_internal.h
@@ -48,7 +48,8 @@ struct logDev_
 			   int create);
   int (*munmap) (logDev * dev, smrLogAddr * addr);
   int (*remove_one) (logDev * dev, long long upper, int gap_in_sec,
-		     int *removed, long long *removed_seq, int *has_more);
+		     long long retain_lb, int *removed,
+		     long long *removed_seq, int *has_more);
   void (*close) (logDev * dev);
 };
 #define init_log_dev(d) do {   \

--- a/smr/smr/log_log.c
+++ b/smr/smr/log_log.c
@@ -410,7 +410,8 @@ smrlog_os_decache (smrLog * handle, long long seq)
 
 int
 smrlog_remove_one (smrLog * handle, long long upper, int gap_in_sec,
-		   int *removed, long long *removed_seq, int *has_more)
+		   long long retain_lb, int *removed, long long *removed_seq,
+		   int *has_more)
 {
   logDev *mem;
   logDev *disk;
@@ -458,8 +459,8 @@ smrlog_remove_one (smrLog * handle, long long upper, int gap_in_sec,
     {
       return 0;
     }
-  return disk->remove_one (disk, upper, gap_in_sec, removed, removed_seq,
-			   has_more);
+  return disk->remove_one (disk, upper, gap_in_sec, retain_lb, removed,
+			   removed_seq, has_more);
 }
 
 int

--- a/smr/smr/log_mem.c
+++ b/smr/smr/log_mem.c
@@ -256,7 +256,8 @@ static smrLogAddr *mem_get_mmap (logDev * dev, long long seq, int for_read,
 static void mem_munmap_internal (masterShm * shm, smrLogAddr * addr);
 static int mem_munmap (logDev * dev, smrLogAddr * addr);
 int mem_remove_one (logDev * dev, long long upper, int gap_in_sec,
-		    int *removed, long long *removed_seq, int *has_more);
+		    long long retain_lb, int *removed, long long *removed_seq,
+		    int *has_more);
 static void mem_close (logDev * dev);
 static void mem_info_cs (masterShm * shm, gpbuf_t * gp);
 
@@ -1766,7 +1767,8 @@ mem_munmap (logDev * dev, smrLogAddr * addr)
 
 int
 mem_remove_one (logDev * dev, long long upper, int gap_in_sec,
-		int *removed, long long *removed_seq, int *has_more)
+		long long retain_lb, int *removed, long long *removed_seq,
+		int *has_more)
 {
   // notihg to implement
   return 0;

--- a/smr/smr/smr_log.h
+++ b/smr/smr/smr_log.h
@@ -128,8 +128,9 @@ extern int smrlog_info_master (char *basedir, char **buf);
 extern smrLog *smrlog_init (char *basedir);
 extern void smrlog_destroy (smrLog * handle);
 extern int smrlog_remove_one (smrLog * handle, long long upper,
-			      int gap_in_sec, int *removed,
-			      long long *removed_seq, int *has_more);
+			      int gap_in_sec, long long retain_lb,
+			      int *removed, long long *removed_seq,
+			      int *has_more);
 extern int smrlog_purge_all (smrLog * handle);
 extern int smrlog_purge_after (smrLog * handle, long long seq_inclusive);
 extern int smrlog_os_decache (smrLog * handle, long long seq);

--- a/smr/smr/smr_log.h
+++ b/smr/smr/smr_log.h
@@ -146,7 +146,7 @@ extern int smrlog_append (smrLog * handle, smrLogAddr * addr, char *buf,
 			  int sz);
 extern int smrlog_sync (smrLog * handle, smrLogAddr * addr);
 extern int smrlog_sync_maps (smrLog * handle, smrLogAddr * src_addr,
-			     smrLogAddr * dest_addr);
+			     int src_off, smrLogAddr * dest_addr);
 extern int smrlog_sync_partial (smrLog * handle, smrLogAddr * addr, int from,
 				int to, int sync);
 extern int smrlog_finalize (smrLog * handle, smrLogAddr * addr);

--- a/smr/test/integrated/Smr.py
+++ b/smr/test/integrated/Smr.py
@@ -142,6 +142,14 @@ class SMR (Proc.Proc):
             raise Exception(resp[0])
         return seg[1:]
 
+    def deletelog(self, retain):
+        resp = self._conn.do_request('deletelog %d' % retain)
+        seg = resp[0].split()
+        if seg[0] != '+OK':
+            raise Exception(resp[0])
+        # returns log_delete_seq set
+        return int(seg[1])
+
     def info(self, section='all'):
         ''' returns map(section --> map(key->value))'''
         resp = self._conn.do_request('info %s' % str(section))

--- a/smr/test/integrated/test_deletelog_cmd.py
+++ b/smr/test/integrated/test_deletelog_cmd.py
@@ -1,0 +1,88 @@
+#
+# Copyright 2015 Naver Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import unittest
+import time
+import Util, Conf, Cm, Pg, Pgs, Smr, Client
+
+class TestDeletelogCmd (unittest.TestCase):
+
+    def test_logdelete(self):
+        cm = None
+        pgs1 = None
+        try:
+            cm = Cm.CM("test_logdelete")
+            cm.create_workspace()
+            pg = Pg.PG(0)
+
+            # pgs --> master
+            pgs = Pgs.PGS(0, 'localhost', 1900, cm.dir)
+            pg.join(pgs, start=True)
+            pgs.smr.wait_role(Smr.SMR.MASTER)
+
+            # make lots of logs
+            clients = []
+            num_clients = 20
+            for i in range (0, num_clients):
+                C = Client.Client()
+                clients.append(C)
+                C.slotid = i
+                C.add(C.slotid, 'localhost', 1909)
+                C.size(64*1024, C.slotid)
+                C.tps(100, C.slotid)
+
+            for C in clients:
+                C.start(C.slotid)
+
+            runtime_limit = 15
+            runtime = 0
+            while runtime < runtime_limit:
+                time.sleep(1)
+                runtime = runtime + 1
+
+            for C in clients:
+                C.stop(C.slotid)
+
+            # checkpoint server
+            pgs.be.ckpt()
+            time.sleep(1.0)
+
+            # delete log
+            log_delete_seq = pgs.smr.deletelog(retain = 0)
+            assert(log_delete_seq > 0), log_delete_seq
+            print ("deltelog 0 returns", log_delete_seq)
+
+            # log delete interval in idle state is 10 sec. (see bio.c)
+            # after than, 1.0 0.9 0.8 ... 0.1, 0.1 ...
+            logdel_timeout = 10 + log_delete_seq/(64*1024*1024)
+            deltime = 0
+            while deltime < logdel_timeout:
+                seqs = pgs.smr.getseq_log()
+                # Note background delete spares one log file (see del_proc in bio.c)
+                if seqs['min'] + 64*1024*1024 == log_delete_seq:
+                    break
+                time.sleep(1)
+                deltime = deltime + 1
+            assert(deltime < logdel_timeout), logdel_timeout
+        finally:
+            if pgs is not None:
+                pgs.kill_smr()
+                pgs.kill_be()
+            if cm is not None:
+                cm.remove_workspace()
+
+if __name__ == '__main__':
+    unittest.main()

--- a/smr/test/runtest.py
+++ b/smr/test/runtest.py
@@ -39,6 +39,7 @@ integrated_tests = [
     './test_be_reconf.py',
     './test_quorum.py',
     './test_logutil.py',
+    './test_deletelog_cmd.py',
     ]
 
 for test in unit_tests:


### PR DESCRIPTION
* Bug fix and enhances 
  - Make readonly managment commands can be spied
  - Remove race condition around smrlog_sync_maps (bugfix)
  - make timestamp issued by master replicator monotonic
* implement deletelog command
* enhance rate limit assertion condition
* fix smrmp token realloc bug
* implement deny-oom command
* bug fix: nil bulk reply parsing error
* set test properties as localhost defaults
